### PR TITLE
fix build for recent version of gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.maiflai:gradle-scalatest:0.21'
+        classpath 'com.github.maiflai:gradle-scalatest:0.25'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0'
         classpath 'net.researchgate:gradle-release:2.7.0'
         classpath "com.github.jengelman.gradle.plugins:shadow:5.2.0"


### PR DESCRIPTION
Due to a build error with gradle 6.6.1, incompatible with older version of com.github.maiflai:gradle-scalatest (was using gradle feature that became private / internal)

```
> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> Could not find matching constructor for: org.gradle.process.internal.DefaultExecActionFactory(org.gradle.api.internal.file.BaseDirFileResolver)

```